### PR TITLE
Fix return done true when iterator calls return

### DIFF
--- a/lib/event-iterator.js
+++ b/lib/event-iterator.js
@@ -12,6 +12,7 @@ class EventIterator {
         const queue = [];
         const listen = this.listen;
         const remove = this.remove;
+        let finaliser = null;
         const push = (value) => {
             const resolution = { value, done: false };
             if (placeholder) {
@@ -30,13 +31,13 @@ class EventIterator {
             if (remove) {
                 remove(push, stop, fail);
             }
-            const resolution = { value: undefined, done: true };
+            finaliser = { value: undefined, done: true };
             if (placeholder) {
-                placeholder.resolve(resolution);
+                placeholder.resolve(finaliser);
                 placeholder = undefined;
             }
             else {
-                queue.push(Promise.resolve(resolution));
+                queue.push(Promise.resolve(finaliser));
             }
         };
         const fail = (error) => {
@@ -57,7 +58,10 @@ class EventIterator {
         listen(push, stop, fail);
         return {
             next(value) {
-                if (queue.length) {
+                if (finaliser) {
+                    return Promise.resolve(finaliser);
+                }
+                else if (queue.length) {
                     return queue.shift();
                 }
                 else {
@@ -70,7 +74,8 @@ class EventIterator {
                 if (remove) {
                     remove(push, stop, fail);
                 }
-                return Promise.resolve({ value: undefined, done: true });
+                finaliser = { value: undefined, done: true };
+                return Promise.resolve(finaliser);
             },
         };
     }

--- a/lib/event-iterator.js
+++ b/lib/event-iterator.js
@@ -30,7 +30,7 @@ class EventIterator {
             if (remove) {
                 remove(push, stop, fail);
             }
-            const resolution = { done: true };
+            const resolution = { value: undefined, done: true };
             if (placeholder) {
                 placeholder.resolve(resolution);
                 placeholder = undefined;
@@ -70,7 +70,7 @@ class EventIterator {
                 if (remove) {
                     remove(push, stop, fail);
                 }
-                return Promise.resolve({ done: true });
+                return Promise.resolve({ value: undefined, done: true });
             },
         };
     }

--- a/src/event-iterator.ts
+++ b/src/event-iterator.ts
@@ -53,7 +53,7 @@ export class EventIterator<T> implements AsyncIterable<T> {
         remove(push, stop, fail)
       }
 
-      const resolution = {done: true} as IteratorResult<T>
+      const resolution = {value: undefined, done: true} as IteratorResult<T>
       if (placeholder) {
         placeholder.resolve(resolution)
         placeholder = undefined
@@ -97,7 +97,7 @@ export class EventIterator<T> implements AsyncIterable<T> {
           remove(push, stop, fail)
         }
 
-        return Promise.resolve({done: true} as IteratorResult<T>)
+        return Promise.resolve({value: undefined, done: true} as IteratorResult<T>)
       },
     }
   }

--- a/src/event-iterator.ts
+++ b/src/event-iterator.ts
@@ -33,6 +33,7 @@ export class EventIterator<T> implements AsyncIterable<T> {
     const queue: AsyncQueue<T> = []
     const listen = this.listen
     const remove = this.remove
+    let finaliser: IteratorResult<T>|null = null
 
     const push: PushCallback<T> = (value: T) => {
       const resolution = {value, done: false}
@@ -53,12 +54,12 @@ export class EventIterator<T> implements AsyncIterable<T> {
         remove(push, stop, fail)
       }
 
-      const resolution = {value: undefined, done: true} as IteratorResult<T>
+      finaliser = {value: undefined, done: true} as IteratorResult<T>
       if (placeholder) {
-        placeholder.resolve(resolution)
+        placeholder.resolve(finaliser)
         placeholder = undefined
       } else {
-        queue.push(Promise.resolve(resolution))
+        queue.push(Promise.resolve(finaliser))
       }
     }
 
@@ -83,7 +84,9 @@ export class EventIterator<T> implements AsyncIterable<T> {
 
     return {
       next(value?: any) {
-        if (queue.length) {
+        if (finaliser) {
+          return Promise.resolve(finaliser)
+        } else if (queue.length) {
           return queue.shift()!
         } else {
           return new Promise((resolve, reject) => {
@@ -97,7 +100,8 @@ export class EventIterator<T> implements AsyncIterable<T> {
           remove(push, stop, fail)
         }
 
-        return Promise.resolve({value: undefined, done: true} as IteratorResult<T>)
+        finaliser = {value: undefined, done: true} as IteratorResult<T>
+        return Promise.resolve(finaliser)
       },
     }
   }

--- a/test/event-iterator-test.ts
+++ b/test/event-iterator-test.ts
@@ -32,7 +32,7 @@ describe("event iterator", function() {
 
       await new Promise(setImmediate)
       const result = await it[Symbol.asyncIterator]().next()
-      assert.deepEqual(result, {done: true})
+      assert.deepEqual(result, {value: undefined, done: true})
     })
 
     it("should await delayed end", async function() {
@@ -42,7 +42,7 @@ describe("event iterator", function() {
 
       await new Promise(setImmediate)
       const result = await it[Symbol.asyncIterator]().next()
-      assert.deepEqual(result, {done: true})
+      assert.deepEqual(result, {value: undefined, done: true})
     })
 
     it("should await immediate error", async function() {
@@ -91,7 +91,7 @@ describe("event iterator", function() {
 
       await new Promise(setImmediate)
       const result = await it[Symbol.asyncIterator]().return!()
-      assert.deepEqual(result, {done: true})
+      assert.deepEqual(result, {value: undefined, done: true})
       assert.equal(removed, 1)
     })
 
@@ -103,7 +103,7 @@ describe("event iterator", function() {
 
       await new Promise(setImmediate)
       const result = await it[Symbol.asyncIterator]().next()
-      assert.deepEqual(result, {done: true})
+      assert.deepEqual(result, {value: undefined, done: true})
       assert.equal(removed, 1)
     })
 
@@ -115,7 +115,7 @@ describe("event iterator", function() {
 
       await new Promise(setImmediate)
       const result = await it[Symbol.asyncIterator]().next()
-      assert.deepEqual(result, {done: true})
+      assert.deepEqual(result, {value: undefined, done: true})
       assert.equal(removed, 1)
     })
 

--- a/test/event-iterator-test.ts
+++ b/test/event-iterator-test.ts
@@ -72,6 +72,29 @@ describe("event iterator", function() {
         assert.instanceOf(err, Error)
       }
     })
+
+    it("does not yield new items if return has been called", async function() {
+      const it = new EventIterator(next => {
+        next("val")
+      })
+
+      await new Promise(setImmediate)
+      const iter = it[Symbol.asyncIterator]()
+      await iter.return?.()
+      assert.deepEqual(await iter.next(), {value: undefined, done: true})
+    })
+
+    it("does not queue for new items if return has been called", async function() {
+      const it = new EventIterator(next => {
+        next("val")
+      })
+
+      await new Promise(setImmediate)
+      const iter = it[Symbol.asyncIterator]()
+      assert.deepEqual(await iter.next(), {value: "val", done: false})
+      await iter.return?.()
+      assert.deepEqual(await iter.next(), {value: undefined, done: true})
+    })
   })
 
   describe("with listen and remove", function() {


### PR DESCRIPTION
## What?

This updates the `return()` method of an EventIterator to set a `finaliser` object to be an `IteratorReturn<T>`. It also updates the `next()` method so that if the `finaliser` is present, to return that.

## Why?

This fixes #3 - which states that when `return()` is called, it should "cancel" the iterator, such that subsequent calls to `next()` also return `{done: true}`. 

I've added tests case to prove these. Without the patch the first test case returns `{value:"val",done:false}` and the second test case hangs until mocha times out.