### PR TITLE
Stream pause

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 package-lock.json
+/.vscode
+/.DS_Store

--- a/README.md
+++ b/README.md
@@ -90,27 +90,21 @@ async iterator; the internal `EventIterator` queue can fill up indefinitely.
 A warning will be emitted when the queue reaches 100 items.
 
 
-However, if you are able to pause the event stream then use the `onPause`, and `onResume` callbacks
+However, if you are able to pause the event stream then use the `onDrain`, and `onFill` callbacks
 
 The limit can be changed or disabled by settings `highWaterMark` in the options of the  `EventIterator` constructor.
 
 ```js
 import { EventIterator } from "event-iterator"
-
-const file = require("fs").createReadStream("example-file")
-
 const eventIterator = new EventIterator(
-  push => {
+  ({push, onDrain, onFill}) => {
+    const file = require("fs").createReadStream("example-file")
     file.on('data', push)
+    onDrain(() => file.pause())
+    onFill(() => file.resume())
+    return () => file.removeListener('data', push)
   },
-  push => {
-    file.removeListener('data', push)
-  },
-  {
-    highWaterMark: 10,
-    onPause: () => file.pause(),
-    onResume: () => file.resume(),
-  }
+  { highWaterMark: 10 }
 )
 ```
 

--- a/lib/event-iterator.d.ts
+++ b/lib/event-iterator.d.ts
@@ -1,23 +1,23 @@
 export declare type PushCallback<T> = (res: T) => void;
 export declare type StopCallback<T> = () => void;
 export declare type FailCallback<T> = (err: Error) => void;
-export declare type OnPauseCallback<T> = () => void;
-export declare type OnResumeCallback<T> = () => void;
-export declare type OnPauseSetter<T> = (fn: OnPauseCallback<T>) => void;
-export declare type OnResumeSetter<T> = (fn: OnResumeCallback<T>) => void;
+export declare type OnDrainCallback<T> = () => void;
+export declare type OnFillCallback<T> = () => void;
+export declare type OnDrainSetter<T> = (fn: OnDrainCallback<T>) => void;
+export declare type OnFillSetter<T> = (fn: OnFillCallback<T>) => void;
 export interface EventQueue<T> {
     push: PushCallback<T>;
     stop: StopCallback<T>;
     fail: FailCallback<T>;
-    onPause: OnPauseSetter<T>;
-    onResume: OnResumeSetter<T>;
+    onDrain: OnDrainSetter<T>;
+    onFill: OnFillSetter<T>;
 }
 export declare type RemoveHandler = () => void;
 export declare type ListenHandler<T> = (eventQueue: EventQueue<T>) => void | RemoveHandler;
 export interface EventIteratorOptions {
     highWaterMark?: number;
-    onPause?: Function;
-    onResume?: Function;
+    onDrain?: Function;
+    onFill?: Function;
 }
 export declare class EventIterator<T> implements AsyncIterable<T> {
     private listen;

--- a/lib/event-iterator.d.ts
+++ b/lib/event-iterator.d.ts
@@ -5,11 +5,14 @@ export declare type ListenHandler<T> = (push: PushCallback<T>, stop: StopCallbac
 export declare type RemoveHandler<T> = (push: PushCallback<T>, stop: StopCallback<T>, fail: FailCallback<T>) => void;
 export interface EventIteratorOptions {
     highWaterMark?: number;
+    onPause?: Function;
+    onResume?: Function;
 }
 export declare class EventIterator<T> implements AsyncIterable<T> {
     private listen;
     private remove?;
     private options;
+    private state;
     constructor(listen: ListenHandler<T>, remove?: RemoveHandler<T>, options?: EventIteratorOptions);
     [Symbol.asyncIterator](): AsyncIterator<T>;
 }

--- a/lib/event-iterator.js
+++ b/lib/event-iterator.js
@@ -4,6 +4,12 @@ class EventIterator {
     constructor(listen, remove, options = {}) {
         this.listen = listen;
         this.remove = remove;
+        this.state = {
+            paused: false
+        };
+        if (options.onPause && !options.onResume) {
+            throw new Error('Cannot define onPause without an onResume');
+        }
         this.options = Object.assign({ highWaterMark: 100 }, options);
         Object.freeze(this);
     }
@@ -13,6 +19,7 @@ class EventIterator {
         const listen = this.listen;
         const remove = this.remove;
         let finaliser = null;
+        const { highWaterMark, onPause, onResume } = this.options;
         const push = (value) => {
             const resolution = { value, done: false };
             if (pullQueue.length) {
@@ -22,9 +29,18 @@ class EventIterator {
             }
             else {
                 pushQueue.push(Promise.resolve(resolution));
-                const { highWaterMark } = this.options;
-                if (highWaterMark !== undefined && pushQueue.length >= highWaterMark && console) {
-                    console.warn(`EventIterator queue reached ${pushQueue.length} items`);
+                if (highWaterMark !== undefined) {
+                    if (pushQueue.length >= highWaterMark) {
+                        if (onPause) {
+                            if (!this.state.paused) {
+                                onPause();
+                                this.state.paused = true;
+                            }
+                        }
+                        else if (console) {
+                            console.warn(`EventIterator queue reached ${pushQueue.length} items`);
+                        }
+                    }
                 }
             }
         };
@@ -62,12 +78,20 @@ class EventIterator {
         };
         listen(push, stop, fail);
         return {
-            next(value) {
+            next: (value) => {
                 if (finaliser) {
                     return Promise.resolve(finaliser);
                 }
                 else if (pushQueue.length) {
-                    return pushQueue.shift();
+                    const result = pushQueue.shift();
+                    if (highWaterMark !== undefined &&
+                        onResume &&
+                        this.state.paused &&
+                        pushQueue.length < highWaterMark) {
+                        onResume();
+                        this.state.paused = false;
+                    }
+                    return result;
                 }
                 else {
                     return new Promise((resolve, reject) => {

--- a/lib/event-iterator.js
+++ b/lib/event-iterator.js
@@ -3,8 +3,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 class EventIterator {
     constructor(listen, options = {}) {
         this.listen = listen;
-        if (options.onPause && !options.onResume) {
-            throw new Error('Cannot define onPause without an onResume');
+        if (options.onDrain && !options.onFill) {
+            throw new Error('Cannot define onDrain without an onFill');
         }
         this.options = Object.assign({ highWaterMark: 100 }, options);
         Object.freeze(this);
@@ -14,8 +14,8 @@ class EventIterator {
         const pushQueue = [];
         const listen = this.listen;
         let remove = () => { };
-        let onPause = null;
-        let onResume = null;
+        let onDrain = null;
+        let onFill = null;
         let finaliser = null;
         let { highWaterMark } = this.options;
         let paused = false;
@@ -30,11 +30,11 @@ class EventIterator {
                 pushQueue.push(Promise.resolve(resolution));
                 if (highWaterMark !== undefined) {
                     if (pushQueue.length >= highWaterMark) {
-                        if (!onPause && console) {
+                        if (!onDrain && console) {
                             console.warn(`EventIterator queue reached ${pushQueue.length} items`);
                         }
-                        else if (onPause && !paused) {
-                            onPause();
+                        else if (onDrain && !paused) {
+                            onDrain();
                             paused = true;
                         }
                     }
@@ -77,8 +77,8 @@ class EventIterator {
             push,
             stop,
             fail,
-            onPause: (fn) => { onPause = fn; },
-            onResume: (fn) => { onResume = fn; },
+            onDrain: (fn) => { onDrain = fn; },
+            onFill: (fn) => { onFill = fn; },
         }) || remove;
         return {
             next: (value) => {
@@ -88,10 +88,10 @@ class EventIterator {
                 else if (pushQueue.length) {
                     const result = pushQueue.shift();
                     if (highWaterMark !== undefined &&
-                        onResume &&
+                        onFill &&
                         paused &&
                         pushQueue.length < highWaterMark) {
-                        onResume();
+                        onFill();
                         paused = false;
                     }
                     return result;

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
     "@types/jsdom": ">= 0",
     "@types/mocha": ">= 0",
     "@types/node": ">= 8.0",
+    "@types/sinon": ">= 7.5.1",
     "chai": ">= 4.1",
     "jsdom": ">= 11.0",
     "mocha": ">= 3.1",
     "ts-node": ">= 3.3",
-    "typescript": ">= 3.3"
+    "typescript": ">= 3.3",
+    "sinon": ">= 7.5.0"
   },
   "scripts": {
     "test": "mocha test/*-test.ts && rm -rf lib && tsc"

--- a/test/event-iterator-test.ts
+++ b/test/event-iterator-test.ts
@@ -223,9 +223,9 @@ describe("event iterator", function() {
       const pauseSpy = spy();
       const resumeSpy = spy();
       const event = new EventEmitter();
-      const it = new EventIterator(({push, onPause, onResume}) => {
-        onPause(pauseSpy)
-        onResume(resumeSpy)
+      const it = new EventIterator(({push, onDrain, onFill}) => {
+        onDrain(pauseSpy)
+        onFill(resumeSpy)
         event.on("data", push)
       }, { highWaterMark: 1 })
 
@@ -239,7 +239,7 @@ describe("event iterator", function() {
       assert.equal(pauseSpy.called, true);
       assert.equal(resumeSpy.called, false);
 
-      // Consume the record in the queue to to trigger onResume
+      // Consume the record in the queue to to trigger onFill
       await iter.next();
 
       assert.equal(resumeSpy.called, true);


### PR DESCRIPTION
This PR adds logic to pause & resume streams if the pushQueue size crosses the highWatermark. 

This PR does include code from https://github.com/rolftimmermans/event-iterator/pull/10 due to some common code dependencies. I would rebase this PR once [10](https://github.com/rolftimmermans/event-iterator/pull/10) is merged in. Only the last commit is relevant to this PR.

### Pausing Streams

If you cannot reasonably consume all emitted events with your
async iterator; the internal `EventIterator` queue can fill up indefinitely.

A warning will be emitted when the queue reaches 100 items.


However, if you are able to pause the event stream then use the `onPause`, and `onResume` callbacks

The limit can be changed or disabled by settings `highWaterMark` in the options of the  `EventIterator` constructor.

```js
import { EventIterator } from "event-iterator"
const file = require("fs").createReadStream("example-file")
const eventIterator = new EventIterator(
  push => {
    file.on('data', push)
  },
  push => {
    file.removeListener('data', push)
  },
  {
    highWaterMark: 10,
    onPause: () => file.pause(),
    onResume: () => file.resume(),
  }
)
```

