### PR TITLE
Event Iterator will flush messages after stream is closed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 package-lock.json
+/.vscode
+/.DS_Store

--- a/lib/event-iterator.d.ts
+++ b/lib/event-iterator.d.ts
@@ -5,11 +5,14 @@ export declare type ListenHandler<T> = (push: PushCallback<T>, stop: StopCallbac
 export declare type RemoveHandler<T> = (push: PushCallback<T>, stop: StopCallback<T>, fail: FailCallback<T>) => void;
 export interface EventIteratorOptions {
     highWaterMark?: number;
+    onPause?: Function;
+    onResume?: Function;
 }
 export declare class EventIterator<T> implements AsyncIterable<T> {
     private listen;
     private remove?;
     private options;
+    private state;
     constructor(listen: ListenHandler<T>, remove?: RemoveHandler<T>, options?: EventIteratorOptions);
     [Symbol.asyncIterator](): AsyncIterator<T>;
 }

--- a/lib/event-iterator.js
+++ b/lib/event-iterator.js
@@ -4,6 +4,12 @@ class EventIterator {
     constructor(listen, remove, options = {}) {
         this.listen = listen;
         this.remove = remove;
+        this.state = {
+            paused: false
+        };
+        if (options.onPause && !options.onResume) {
+            throw new Error('Cannot define onPause without an onResume');
+        }
         this.options = Object.assign({ highWaterMark: 100 }, options);
         Object.freeze(this);
     }
@@ -13,6 +19,7 @@ class EventIterator {
         const listen = this.listen;
         const remove = this.remove;
         let finaliser = null;
+        const { highWaterMark, onPause, onResume } = this.options;
         const push = (value) => {
             const resolution = { value, done: false };
             if (pullQueue.length) {
@@ -22,9 +29,18 @@ class EventIterator {
             }
             else {
                 pushQueue.push(Promise.resolve(resolution));
-                const { highWaterMark } = this.options;
-                if (highWaterMark !== undefined && pushQueue.length >= highWaterMark && console) {
-                    console.warn(`EventIterator queue reached ${pushQueue.length} items`);
+                if (highWaterMark !== undefined) {
+                    if (pushQueue.length >= highWaterMark) {
+                        if (onPause) {
+                            if (!this.state.paused) {
+                                onPause();
+                                this.state.paused = true;
+                            }
+                        }
+                        else if (console) {
+                            console.warn(`EventIterator queue reached ${pushQueue.length} items`);
+                        }
+                    }
                 }
             }
         };
@@ -62,12 +78,20 @@ class EventIterator {
         };
         listen(push, stop, fail);
         return {
-            next(value) {
+            next: (value) => {
                 if (finaliser) {
                     return Promise.resolve(finaliser);
                 }
                 else if (pushQueue.length) {
-                    return pushQueue.shift();
+                    const result = pushQueue.shift();
+                    if (highWaterMark !== undefined &&
+                        onResume &&
+                        this.state.paused &&
+                        pushQueue.length < highWaterMark) {
+                        onResume();
+                        this.state.paused = false;
+                    }
+                    return result;
                 }
                 else {
                     return new Promise((resolve, reject) => {

--- a/lib/event-iterator.js
+++ b/lib/event-iterator.js
@@ -79,10 +79,7 @@ class EventIterator {
         listen(push, stop, fail);
         return {
             next: (value) => {
-                if (finaliser) {
-                    return Promise.resolve(finaliser);
-                }
-                else if (pushQueue.length) {
+                if (pushQueue.length) {
                     const result = pushQueue.shift();
                     if (highWaterMark !== undefined &&
                         onResume &&
@@ -92,6 +89,9 @@ class EventIterator {
                         this.state.paused = false;
                     }
                     return result;
+                }
+                else if (finaliser) {
+                    return Promise.resolve(finaliser);
                 }
                 else {
                     return new Promise((resolve, reject) => {
@@ -103,6 +103,7 @@ class EventIterator {
                 if (remove) {
                     remove(push, stop, fail);
                 }
+                pushQueue.splice(0, pushQueue.length);
                 finaliser = { value: undefined, done: true };
                 return Promise.resolve(finaliser);
             },

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
     "@types/jsdom": ">= 0",
     "@types/mocha": ">= 0",
     "@types/node": ">= 8.0",
+    "@types/sinon": ">= 7.5.1",
     "chai": ">= 4.1",
     "jsdom": ">= 11.0",
     "mocha": ">= 3.1",
     "ts-node": ">= 3.3",
-    "typescript": ">= 3.3"
+    "typescript": ">= 3.3",
+    "sinon": ">= 7.5.0"
   },
   "scripts": {
     "test": "mocha test/*-test.ts && rm -rf lib && tsc"

--- a/src/event-iterator.ts
+++ b/src/event-iterator.ts
@@ -122,9 +122,7 @@ export class EventIterator<T> implements AsyncIterable<T> {
 
     return {
       next: (value?: any) => {
-        if (finaliser) {
-          return Promise.resolve(finaliser)
-        } else if (pushQueue.length) {
+        if (pushQueue.length) {
           const result = pushQueue.shift()!
           
           if (
@@ -138,6 +136,8 @@ export class EventIterator<T> implements AsyncIterable<T> {
           }
           
           return result;
+        } else if (finaliser) {
+          return Promise.resolve(finaliser)
         } else {
           return new Promise((resolve, reject) => {
             pullQueue.push({ resolve, reject })
@@ -150,6 +150,7 @@ export class EventIterator<T> implements AsyncIterable<T> {
           remove(push, stop, fail)
         }
 
+        pushQueue.splice(0, pushQueue.length);
         finaliser = { value: undefined, done: true } as IteratorResult<T>
         return Promise.resolve(finaliser)
       },


### PR DESCRIPTION
This is based on top of https://github.com/rolftimmermans/event-iterator/pull/11 since there is dependant code. I'll rebase once 11 is merged in. Only the last commit is relevant to this PR.

The event iterator will continue to flush messages from before the event stream is stopped. https://github.com/rolftimmermans/event-iterator/issues/12