### PR TITLE
refactor: rework call signature for EventIterator

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -3,10 +3,9 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const event_iterator_1 = require("./event-iterator");
 exports.EventIterator = event_iterator_1.EventIterator;
 function subscribe(event, options, evOptions) {
-    return new event_iterator_1.EventIterator((push) => {
+    return new event_iterator_1.EventIterator(({ push }) => {
         this.addEventListener(event, push, options);
-    }, (push) => {
-        this.removeEventListener(event, push, options);
+        return () => this.removeEventListener(event, push, options);
     }, evOptions);
 }
 exports.subscribe = subscribe;

--- a/lib/event-iterator.d.ts
+++ b/lib/event-iterator.d.ts
@@ -1,16 +1,20 @@
 export declare type PushCallback<T> = (res: T) => void;
 export declare type StopCallback<T> = () => void;
 export declare type FailCallback<T> = (err: Error) => void;
-export declare type ListenHandler<T> = (push: PushCallback<T>, stop: StopCallback<T>, fail: FailCallback<T>) => void;
-export declare type RemoveHandler<T> = (push: PushCallback<T>, stop: StopCallback<T>, fail: FailCallback<T>) => void;
+export interface EventQueue<T> {
+    push: PushCallback<T>;
+    stop: StopCallback<T>;
+    fail: FailCallback<T>;
+}
+export declare type RemoveHandler = () => void;
+export declare type ListenHandler<T> = (eventQueue: EventQueue<T>) => void | RemoveHandler;
 export interface EventIteratorOptions {
     highWaterMark?: number;
 }
 export declare class EventIterator<T> implements AsyncIterable<T> {
     private listen;
-    private remove?;
     private options;
-    constructor(listen: ListenHandler<T>, remove?: RemoveHandler<T>, options?: EventIteratorOptions);
+    constructor(listen: ListenHandler<T>, options?: EventIteratorOptions);
     [Symbol.asyncIterator](): AsyncIterator<T>;
 }
 export default EventIterator;

--- a/lib/event-iterator.js
+++ b/lib/event-iterator.js
@@ -1,9 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 class EventIterator {
-    constructor(listen, remove, options = {}) {
+    constructor(listen, options = {}) {
         this.listen = listen;
-        this.remove = remove;
         this.options = Object.assign({ highWaterMark: 100 }, options);
         Object.freeze(this);
     }
@@ -11,7 +10,7 @@ class EventIterator {
         let pullQueue = [];
         const pushQueue = [];
         const listen = this.listen;
-        const remove = this.remove;
+        let remove = () => { };
         let finaliser = null;
         const push = (value) => {
             const resolution = { value, done: false };
@@ -29,38 +28,38 @@ class EventIterator {
             }
         };
         const stop = () => {
-            if (remove) {
-                remove(push, stop, fail);
-            }
-            finaliser = { value: undefined, done: true };
-            if (pullQueue.length) {
-                for (const placeholder of pullQueue) {
-                    placeholder.resolve(finaliser);
+            Promise.resolve().then(() => {
+                remove();
+                finaliser = { value: undefined, done: true };
+                if (pullQueue.length) {
+                    for (const placeholder of pullQueue) {
+                        placeholder.resolve(finaliser);
+                    }
+                    pullQueue = [];
                 }
-                pullQueue = [];
-            }
-            else {
-                pushQueue.push(Promise.resolve(finaliser));
-            }
+                else {
+                    pushQueue.push(Promise.resolve(finaliser));
+                }
+            });
         };
         const fail = (error) => {
-            if (remove) {
-                remove(push, stop, fail);
-            }
-            if (pullQueue.length) {
-                for (const placeholder of pullQueue) {
-                    placeholder.reject(error);
+            Promise.resolve().then(() => {
+                remove();
+                if (pullQueue.length) {
+                    for (const placeholder of pullQueue) {
+                        placeholder.reject(error);
+                    }
+                    pullQueue = [];
                 }
-                pullQueue = [];
-            }
-            else {
-                const rejection = Promise.reject(error);
-                /* Attach error handler to avoid leaking an unhandled promise rejection. */
-                rejection.catch(() => { });
-                pushQueue.push(rejection);
-            }
+                else {
+                    const rejection = Promise.reject(error);
+                    /* Attach error handler to avoid leaking an unhandled promise rejection. */
+                    rejection.catch(() => { });
+                    pushQueue.push(rejection);
+                }
+            });
         };
-        listen(push, stop, fail);
+        remove = listen({ push, stop, fail }) || remove;
         return {
             next(value) {
                 if (finaliser) {
@@ -76,9 +75,7 @@ class EventIterator {
                 }
             },
             return() {
-                if (remove) {
-                    remove(push, stop, fail);
-                }
+                remove();
                 finaliser = { value: undefined, done: true };
                 return Promise.resolve(finaliser);
             },

--- a/lib/node.js
+++ b/lib/node.js
@@ -3,21 +3,22 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const event_iterator_1 = require("./event-iterator");
 exports.EventIterator = event_iterator_1.EventIterator;
 function stream(evOptions) {
-    return new event_iterator_1.EventIterator((push, stop, fail) => {
+    return new event_iterator_1.EventIterator(({ push, stop, fail }) => {
         this.addListener("data", push);
         this.addListener("end", stop);
         this.addListener("error", fail);
-    }, (push, stop, fail) => {
-        this.removeListener("data", push);
-        this.removeListener("end", stop);
-        this.removeListener("error", fail);
-        /* We are no longer interested in any data; attempt to close the stream. */
-        if (this.destroy) {
-            this.destroy();
-        }
-        else if (typeof this.close == "function") {
-            this.close();
-        }
+        return () => {
+            this.removeListener("data", push);
+            this.removeListener("end", stop);
+            this.removeListener("error", fail);
+            /* We are no longer interested in any data; attempt to close the stream. */
+            if (this.destroy) {
+                this.destroy();
+            }
+            else if (typeof this.close == "function") {
+                this.close();
+            }
+        };
     }, evOptions);
 }
 exports.stream = stream;

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -2,14 +2,10 @@ import {EventIterator, EventIteratorOptions} from "./event-iterator"
 
 export function subscribe(this: EventTarget, event: string, options?: AddEventListenerOptions, evOptions?: EventIteratorOptions) {
   return new EventIterator<Event>(
-    (push) => {
+    ({push}) => {
       this.addEventListener(event, push, options)
+      return () => this.removeEventListener(event, push, options)
     },
-
-    (push) => {
-      this.removeEventListener(event, push, options)
-    },
-
     evOptions,
   )
 }

--- a/src/node.ts
+++ b/src/node.ts
@@ -3,25 +3,23 @@ import {EventIterator, EventIteratorOptions} from "./event-iterator"
 
 export function stream(this: Readable, evOptions?: EventIteratorOptions) {
   return new EventIterator<Buffer>(
-    (push, stop, fail) => {
+    ({ push, stop, fail }) => {
       this.addListener("data", push)
       this.addListener("end", stop)
       this.addListener("error", fail)
-    },
+      return () => {
+        this.removeListener("data", push)
+        this.removeListener("end", stop)
+        this.removeListener("error", fail)
 
-    (push, stop, fail) => {
-      this.removeListener("data", push)
-      this.removeListener("end", stop)
-      this.removeListener("error", fail)
-
-      /* We are no longer interested in any data; attempt to close the stream. */
-      if (this.destroy) {
-        this.destroy()
-      } else if (typeof (this as any).close == "function") {
-        (this as any).close()
+        /* We are no longer interested in any data; attempt to close the stream. */
+        if (this.destroy) {
+          this.destroy()
+        } else if (typeof (this as any).close == "function") {
+          (this as any).close()
+        }
       }
     },
-
     evOptions,
   )
 }

--- a/test/event-iterator-test.ts
+++ b/test/event-iterator-test.ts
@@ -7,8 +7,8 @@ import {EventEmitter} from 'events';
 describe("event iterator", function() {
   describe("with listen", function() {
     it("should await immediate value", async function() {
-      const it = new EventIterator(next => {
-        next("val")
+      const it = new EventIterator(({ push }) => {
+        push("val")
       })
 
       await new Promise(setImmediate)
@@ -17,8 +17,8 @@ describe("event iterator", function() {
     })
 
     it("should await delayed value", async function() {
-      const it = new EventIterator(next => {
-        setImmediate(() => next("val"))
+      const it = new EventIterator(({ push }) => {
+        setImmediate(() => push("val"))
       })
 
       await new Promise(setImmediate)
@@ -27,7 +27,7 @@ describe("event iterator", function() {
     })
 
     it("should await immediate end", async function() {
-      const it = new EventIterator((next, stop) => {
+      const it = new EventIterator(({ push, stop }) => {
         stop()
       })
 
@@ -37,7 +37,7 @@ describe("event iterator", function() {
     })
 
     it("should await delayed end", async function() {
-      const it = new EventIterator((next, stop) => {
+      const it = new EventIterator(({ push, stop }) => {
         setImmediate(stop)
       })
 
@@ -47,7 +47,7 @@ describe("event iterator", function() {
     })
 
     it("should await immediate error", async function() {
-      const it = new EventIterator((next, stop, fail) => {
+      const it = new EventIterator(({ push, stop, fail }) => {
         fail(new Error)
       })
 
@@ -61,7 +61,7 @@ describe("event iterator", function() {
     })
 
     it("should await delayed error", async function() {
-      const it = new EventIterator((next, stop, fail) => {
+      const it = new EventIterator(({ push, stop, fail }) => {
         setImmediate(() => fail(new Error))
       })
 
@@ -75,8 +75,8 @@ describe("event iterator", function() {
     })
 
     it("does not yield new items if return has been called", async function() {
-      const it = new EventIterator(next => {
-        next("val")
+      const it = new EventIterator(({ push }) => {
+        push("val")
       })
 
       await new Promise(setImmediate)
@@ -86,8 +86,8 @@ describe("event iterator", function() {
     })
 
     it("does not queue for new items if return has been called", async function() {
-      const it = new EventIterator(next => {
-        next("val")
+      const it = new EventIterator(({ push }) => {
+        push("val")
       })
 
       await new Promise(setImmediate)
@@ -99,19 +99,22 @@ describe("event iterator", function() {
   })
 
   describe("with listen and remove", function() {
-    it("should call handlers with identical arguments", async function() {
-      let a, b
+    it("should call remove handler with no arguments", async function() {
+      let removeArgs = null
       const it = new EventIterator(
-        (...args: any[]) => a = args,
-        (...args: any[]) => b = args,
+        ({ stop }) => {
+          stop()
+          return (...args: any[]) => removeArgs = args
+        },
       )
-
-      assert.equal(a, b)
+      await new Promise(setImmediate)
+      const result = await it[Symbol.asyncIterator]().return!()
+      assert.deepStrictEqual(removeArgs, [])
     })
 
     it("should call remove handler on return", async function() {
       let removed = 0
-      const it = new EventIterator(() => {}, () => removed += 1)
+      const it = new EventIterator(() => () => removed += 1)
 
       await new Promise(setImmediate)
       const result = await it[Symbol.asyncIterator]().return!()
@@ -121,9 +124,10 @@ describe("event iterator", function() {
 
     it("should call remove handler on immediate end", async function() {
       let removed = 0
-      const it = new EventIterator((next, stop) => {
+      const it = new EventIterator(({ stop }) => {
         stop()
-      }, () => removed += 1)
+        return () => removed += 1
+      })
 
       await new Promise(setImmediate)
       const result = await it[Symbol.asyncIterator]().next()
@@ -133,9 +137,10 @@ describe("event iterator", function() {
 
     it("should call remove handler on delayed end", async function() {
       let removed = 0
-      const it = new EventIterator((next, stop) => {
+      const it = new EventIterator(({ stop }) => {
         setImmediate(stop)
-      }, () => removed += 1)
+        return () => removed += 1
+      })
 
       await new Promise(setImmediate)
       const result = await it[Symbol.asyncIterator]().next()
@@ -145,9 +150,10 @@ describe("event iterator", function() {
 
     it("should call remove handler on immediate error", async function() {
       let removed = 0
-      const it = new EventIterator((next, stop, fail) => {
+      const it = new EventIterator(({ fail }) => {
         fail(new Error)
-      }, () => removed += 1)
+        return () => removed += 1
+      })
 
       try {
         await new Promise(setImmediate)
@@ -161,9 +167,10 @@ describe("event iterator", function() {
 
     it("should call remove handler on delayed error", async function() {
       let removed = 0
-      const it = new EventIterator((next, stop, fail) => {
+      const it = new EventIterator(({ fail }) => {
         setImmediate(() => fail(new Error))
-      }, () => removed += 1)
+        return () => removed += 1
+      })
 
       try {
         await new Promise(setImmediate)
@@ -177,24 +184,23 @@ describe("event iterator", function() {
 
     it("should buffer iterator calls when the queue is empty", async function() {
       const event = new EventEmitter();
-      const it = new EventIterator((next, stop, fail) => {
-        event.on('data', next);
-      }, (next) => {
-        event.removeListener('data', next);
-      });
+      const it = new EventIterator(({ push, stop, fail }) => {
+        event.on('data', push);
+        return () => event.removeListener('data', push)
+      })
 
-      const iterator = it[Symbol.asyncIterator]();
-  
+      const iterator = it[Symbol.asyncIterator]()
+
       const requests = Promise.all([
         iterator.next(),
         iterator.next(),
-      ]);
-  
-      event.emit('data', 'a');
-      event.emit('data', 'b');
-  
-      const result = await requests;
-      assert.deepEqual(result, [{ value: 'a', done: false }, { value: 'b', done: false }]);
+      ])
+
+      event.emit('data', 'a')
+      event.emit('data', 'b')
+
+      const result = await requests
+      assert.deepEqual(result, [{ value: 'a', done: false }, { value: 'b', done: false }])
     })
   })
 
@@ -203,7 +209,7 @@ describe("event iterator", function() {
       const oldconsole = console
       const log = global.console = new MemoryConsole
 
-      const it = new EventIterator(next => {next("val")}, undefined, {highWaterMark: 1})
+      const it = new EventIterator(({ push }) => {push("val")}, {highWaterMark: 1})
 
       await new Promise(setImmediate)
       const result = await it[Symbol.asyncIterator]().next()


### PR DESCRIPTION
As per #8, the call signature for EventIterator now takes an "EventQueue" object which contains the "push", "stop" and "fail" methods, and expects a return value of an optional RemoveHandler. The second RemoveHandler second argument has been removed.

To facilitate this, the "stop" and "fail" methods now process after one Promise.resolve() tick, making them asynchronous. This allows time to retain the RemoveHandler from the ListenHandler in order to call any cleanup operations.

BREAKING CHANGES:

 - The EventIterator function now has an arity of 2 instead of 3. The second "RemoveHandler" argument has been removed. Consumers should update their code such that the "RemoveHandler" should be passed as a return value of the "ListenHandler", as opposed to the second argument of the EventIterator call.

 - The ListenHandler is now called with one argument, as opposed to 3. The single argument is an EventQueue object which contains the "push", "stop" and "fail" functions. Consumers should update their code such that the ListenHandler is only given one argument, which could be a destructured object of `{ push, stop, fail }`.

 - Stop and Fail calls are now asynchronous. Consumers which hoisted these functions and expected them to synchronously call the RemoveHandler should update their code to account for this asynchrony, or update their code to avoid hoisting these arguments.